### PR TITLE
Fixed bug in IdeaCipher#mul() method

### DIFF
--- a/src/main/java/com/davidmiguel/idea_cipher/crypto/IdeaCipher.java
+++ b/src/main/java/com/davidmiguel/idea_cipher/crypto/IdeaCipher.java
@@ -166,7 +166,7 @@ public class IdeaCipher extends BlockCipher {
             if (x != 0 || y != 0) {
                 return (1 - x - y) & 0xFFFF;
             }
-            return 0;
+            return 1;
         }
     }
 


### PR DESCRIPTION
Im dying.

I've spent about 10 hours to find out why decrypted file has defective blocks.
The problem was int one symbol!
Multiplication of two zeros is 1, not 0